### PR TITLE
Removed toLowerCase() on key names in API

### DIFF
--- a/components/objectDefinitionTable.js
+++ b/components/objectDefinitionTable.js
@@ -26,7 +26,7 @@ class ObjectDefinitionTable extends Component {
           {definitions && definitions.entrySeq().map(([key, definition]) =>
             <tr key={key}>
               <td>
-                <strong>{key.toLowerCase()}</strong><br />
+                <strong>{key}</strong><br />
                 <small><em>{definition.get('type')}</em></small>
               </td>
               <td>


### PR DESCRIPTION
Just wanted to allow the theme to support camelCase for API properties. Unless there is a reason I'm unaware of that it's forcing property names to lower case?