### PR TITLE
Nested obj/array support, more draft-04 keywords, better menu linking, etc.

### DIFF
--- a/components/app.js
+++ b/components/app.js
@@ -23,7 +23,7 @@ class App extends Component {
               <div className="col-lg-12">
                 <h1>{config.title}</h1>
                 {schemas
-                  .filter(schema => !schema.get('hidden'))
+                  .filter(schema => !schema.get('cfHidden'))
                   .valueSeq()
                   .map(schema => <Schema key={schema.get('id')} schema={schema} />)
                 }

--- a/components/constraints.js
+++ b/components/constraints.js
@@ -23,6 +23,7 @@ class Constraints extends Component {
     if (!constraints) return <div />;
     return (
       <ul className="constraints">
+        {constraints.get('readOnly') && <li className="read-only">read only</li>}
         {constraints.has('default') &&
           <li>{`default value: ${constraints.get('default')}`}</li>
         }
@@ -76,7 +77,6 @@ class Constraints extends Component {
           constraints.get('type') === 'boolean' && <li>valid values: (true,false)</li>
         }
 
-        {constraints.get('readOnly') && <li>read only</li>}
         {constraints.get('pattern') && <li>pattern: {constraints.get('pattern')}</li>}
         {constraints.get('cfNotes') && <li>notes: {constraints.get('cfNotes')}</li>}
       </ul>

--- a/components/constraints.js
+++ b/components/constraints.js
@@ -27,6 +27,24 @@ class Constraints extends Component {
           <li>{`default value: ${constraints.get('default')}`}</li>
         }
 
+        {(constraints.get('minItems') || constraints.get('minItems') === 0) &&
+          <li>min length: {constraints.get('minItems')}</li>
+        }
+
+        {(constraints.get('maxItems') || constraints.get('maxItems') === 0) &&
+          <li>max length: {constraints.get('maxItems')}</li>
+        }
+
+        {constraints.get('uniqueItems') && <li>unique items</li>}
+
+        {(constraints.get('minProperties') || constraints.get('minProperties') === 0) &&
+          <li>min length: {constraints.get('minProperties')}</li>
+        }
+
+        {(constraints.get('maxProperties') || constraints.get('maxProperties') === 0) &&
+          <li>max length: {constraints.get('maxProperties')}</li>
+        }
+
         {(constraints.get('minLength') || constraints.get('minLength') === 0) &&
           <li>min length: {constraints.get('minLength')}</li>
         }
@@ -36,11 +54,17 @@ class Constraints extends Component {
         }
 
         {(constraints.get('minimum') || constraints.get('minimum') === 0) &&
-          <li>min value: {constraints.get('minimum')}</li>
+          <li>
+            min value{constraints.get('exclusiveMinimum') && ' (exclusive)'}:
+            {constraints.get('minimum')}
+          </li>
         }
 
         {(constraints.get('maximum') || constraints.get('maximum') === 0) &&
-          <li>max value: {constraints.get('maximum')}</li>
+          <li>
+            max value{constraints.get('exclusiveMaximum') && ' (exclusive)'}:
+            {constraints.get('maximum')}
+          </li>
         }
 
         {constraints.get('enum') ?
@@ -54,7 +78,7 @@ class Constraints extends Component {
 
         {constraints.get('readOnly') && <li>read only</li>}
         {constraints.get('pattern') && <li>pattern: {constraints.get('pattern')}</li>}
-        {constraints.get('notes') && <li>notes: {constraints.get('notes')}</li>}
+        {constraints.get('cfNotes') && <li>notes: {constraints.get('cfNotes')}</li>}
       </ul>
     );
   }

--- a/components/definition.js
+++ b/components/definition.js
@@ -8,6 +8,8 @@ class Definition extends Component {
 
   static propTypes = {
     definitions: ImmutablePropTypes.map,
+    contextId: React.PropTypes.string,
+    fieldPointer: React.PropTypes.string,
   };
 
   state = {

--- a/components/endpoint.js
+++ b/components/endpoint.js
@@ -33,6 +33,8 @@ class Endpoint extends Component {
                   link.getIn(['parameters', 'required_props']).indexOf(key) > -1
                 )
               }
+              contextId={link.get('title')}
+              fieldPointer="/properties"
             />
           </div>
         }
@@ -46,6 +48,8 @@ class Endpoint extends Component {
                   link.getIn(['parameters', 'optional_props']).indexOf(key) > -1
                 )
               }
+              contextId={link.get('title')}
+              fieldPointer="/properties"
             />
           </div>
         }

--- a/components/objectDefinitionTable.js
+++ b/components/objectDefinitionTable.js
@@ -2,6 +2,7 @@ const React = require('react');
 const Constraints = require('./constraints');
 const MarkdownPreview = require('react-marked-markdown').MarkdownPreview;
 const List = require('immutable').List;
+const ImmutableMap = require('immutable').Map;
 const ImmutablePropTypes = require('react-immutable-proptypes');
 const Component = require('react-pure-render/component');
 const Definition = require('./definition');
@@ -10,6 +11,8 @@ class ObjectDefinitionTable extends Component {
 
   static propTypes = {
     definitions: ImmutablePropTypes.map,
+    contextId: React.PropTypes.string,
+    fieldPointer: React.PropTypes.string
   };
 
   render() {
@@ -51,15 +54,33 @@ class ObjectDefinitionTable extends Component {
                   {definition.get('anyOf') && <span><br />Any of the following:</span>}
                 </div>
 
-                {definition.get('all_props') &&
-                  <Definition definitions={definition.get('all_props')} />
+                {definition.get('properties') &&
+                  <Definition
+                    definitions={definition.get('properties')}
+                    contextId={this.props.contextId}
+                    fieldPointer={this.props.fieldPointer + '/' + key}
+                  />
+                }
+
+                {definition.get('items') &&
+                  <Definition
+                    definitions={ImmutableMap({'[*]': definition.get('items')})}
+                    contextId={this.props.contextId}
+                    fieldPointer={this.props.fieldPointer + '/' + key}
+                  />
                 }
 
                 {definition.get('oneOf') &&
                   definition.get('oneOf').entrySeq().map(([subkey, subdefinition]) =>
                     <div key={subkey}>
                       <h6>{subdefinition.get('description')}</h6>
-                      <Definition definitions={subdefinition.get('all_props')} />
+                      <Definition
+                        definitions={subdefinition.get('all_props')}
+                        contextId={this.props.contextId}
+                        fieldPointer={this.props.fieldPointer +
+                                      '/' + key +
+                                      '/oneOf/' + subkey}
+                      />
                     </div>
                 )}
 
@@ -67,7 +88,14 @@ class ObjectDefinitionTable extends Component {
                   definition.get('anyOf').entrySeq().map(([subkey, subdefinition]) =>
                     <div key={subkey}>
                       <h6>{subdefinition.get('description')}</h6>
-                      <Definition definitions={subdefinition.get('all_props')} />
+                      <Definition
+                        definitions={subdefinition.get('all_props')}
+                        contextId={this.props.contextId}
+                        fieldPointer={this.props.fieldPointer +
+                                      '/' + key +
+                                      '/anyOf/' + subkey +
+                                      '/properties/'}
+                      />
                     </div>
                 )}
               </td>

--- a/components/objectDefinitionTable.js
+++ b/components/objectDefinitionTable.js
@@ -29,9 +29,13 @@ class ObjectDefinitionTable extends Component {
               <td>
                 <p>
                   <strong>{key}</strong><br />
-                  <small><em>{List.isList(definition.get('type')) ?
-                  definition.get('type').valueSeq().join(', ') :
-                  definition.get('type')}</em></small>
+                  <small><em>
+                    {List.isList(definition.get('type')) ?
+                      definition.get('type').valueSeq().join(', ') :
+                      definition.get('type')}
+                    {definition.get('format') &&
+                      ' (' + definition.get('format') + ')'}
+                  </em></small>
                 </p>
               </td>
               <td>

--- a/components/schema.js
+++ b/components/schema.js
@@ -33,8 +33,8 @@ class Schema extends Component {
         </div>
         <div className="panel-body">
           <h3>{schema.get('description')}</h3>
-          {schema.get('extended_description') &&
-            <MarkdownPreview value={schema.get('extended_description')} />}
+          {schema.get('cfExtendedDescription') &&
+            <MarkdownPreview value={schema.get('cfExtendedDescription')} />}
 
           <header id={`${schema.get('html_id')}-properties`}>
             {IS_JAVASCRIPT &&
@@ -80,7 +80,7 @@ class Schema extends Component {
         <div className="list-group">
           {schema
             .get('links')
-            .filter(link => !link.get('private'))
+            .filter(link => !link.get('cfPrivate'))
             .valueSeq()
             .map(link => <Endpoint key={link.get('html_id')} link={link} />)
           }

--- a/components/schema.js
+++ b/components/schema.js
@@ -51,7 +51,7 @@ class Schema extends Component {
             <div>
               {schema.getIn(['object_definition', 'objects']).count() ?
                 <div>
-                  {schema.getIn(['object_definition', 'objects']).valueSeq().map(obj =>
+                  {schema.getIn(['object_definition', 'objects']).valueSeq().map((obj, index) =>
                     <div key={obj.get('title')}>
                       {obj.get('title') &&
                         <div>
@@ -59,7 +59,14 @@ class Schema extends Component {
                         </div>
                       }
                       {obj.get('example') && <ExampleObject example={obj.get('example')} />}
-                      <ObjectDefinitionTable definitions={obj.get('all_props')} />
+                      <ObjectDefinitionTable
+                        definitions={obj.get('all_props')}
+                        contextId={obj.get('title')}
+                        fieldPointer={
+                          '/' + schema.getIn(['object_definition', 'which_of']) +
+                          '/' + index + '/properties'
+                        }
+                      />
                     </div>
                   )}
                 </div>
@@ -71,6 +78,8 @@ class Schema extends Component {
 
                   <ObjectDefinitionTable
                     definitions={schema.getIn(['object_definition', 'all_props'])}
+                    contextId={schema.getIn(['object_definition', 'title'])}
+                    fieldPointer="/properties"
                   />
                 </div>
               }

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -8,7 +8,7 @@ const offsetTop = require('./helpers').offsetTop;
 const getLinks = (links, search) =>
   links
     .filter(link => {
-      if (link.get('private')) return false;
+      if (link.get('cfPrivate')) return false;
       if (search &&
         link.get('title').toLowerCase().indexOf(search.toLowerCase()) === -1) {
         return false;
@@ -62,13 +62,13 @@ class Sidebar extends Component {
     // list of all link #ids
     const ids = this.props.schemas.reduce((result, schema) => {
       let res = result;
-      if (!schema.get('hidden')) {
+      if (!schema.get('cfHidden')) {
         res = res.concat([`${schema.get('html_id')}-properties`]);
       }
       return res.concat(
         schema
           .get('links')
-          .filter(link => !link.get('private'))
+          .filter(link => !link.get('cfPrivate'))
           .map(link => link.get('html_id'))
           .toJS()
       );
@@ -112,7 +112,7 @@ class Sidebar extends Component {
             onChange={this.handleSearchChange}
           />
         </div>
-        {schemas.filter(schema => !schema.get('hidden')).valueSeq().map(schema =>
+        {schemas.filter(schema => !schema.get('cfHidden')).valueSeq().map(schema =>
           (getLinks(schema.get('links'), search).count() > 0 ?
             <ul className="sidebar-nav" key={schema.get('id')}>
               <li className="sidebar-category">{schema.get('title')}</li>

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -63,6 +63,7 @@ class Sidebar extends Component {
     const ids = this.props.schemas.reduce((result, schema) => {
       let res = result;
       if (!schema.get('cfHidden')) {
+        res = res.concat([schema.get('html_id')]);
         res = res.concat([`${schema.get('html_id')}-properties`]);
       }
       return res.concat(
@@ -115,7 +116,7 @@ class Sidebar extends Component {
         {schemas.filter(schema => !schema.get('cfHidden')).valueSeq().map(schema =>
           (getLinks(schema.get('links'), search).count() > 0 ?
             <ul className="sidebar-nav" key={schema.get('id')}>
-              <li className="sidebar-category">{schema.get('title')}</li>
+              <li className="sidebar-category"><a href={`#${schema.get('html_id')}`}>{schema.get('title')}</a></li>
               {getLinks(schema.get('links'), search).valueSeq().map(link =>
                 <li
                   key={link.get('html_id')}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doca-bootstrap-theme",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "Doca theme using Twitter Bootstrap",
   "main": "index.js",
   "author": "Vojtech Miksu <vojtech@miksu.cz>",
@@ -30,6 +30,9 @@
     "react-immutable-proptypes": "^1.7.1",
     "react-marked-markdown": "^1.4.0",
     "react-pure-render": "^1.0.2"
+  },
+  "peerDependencies": {
+    "json-schema-example-loader": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -261,3 +261,9 @@ pre {
   border-radius: 0;
 }
 
+code {
+  max-height: 16.66667em;
+  max-width: 30em;
+  overflow: scroll;
+  white-space: pre;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -267,3 +267,8 @@ code {
   overflow: scroll;
   white-space: pre;
 }
+
+li.read-only {
+  font-weight: bolder;
+  font-style: italic ;
+}


### PR DESCRIPTION
This fixes lots of stuff, and generally brings doca-bootstrap-theme into parity with our internal theme (including nested object support which as of today we haven't even deployed yet!)

While it's an omnibus PR overall, the changes are split up into commits that each do a specific thing and can be split out if something gets hung up.

This addresses:
* https://github.com/cloudflare/doca/issues/17 (nested objects and arrays)
* https://github.com/cloudflare/doca/issues/59 (`minItems`, `maxItems`, `uniqueItems`)
* https://github.com/cloudflare/doca/issues/60 (`minProperties`, `maxProperties`)
* https://github.com/cloudflare/doca/issues/61 (draft-04 boolean-style `exclusive[Minimum|Maximum]`)
* https://github.com/cloudflare/doca/issues/50 (display boolean defaults- this might have been fixed at some earlier point, but definitely seems to work now even though I didn't do anything for it)

Additionally, this change:
* displays formatted example JSON for each field with proper indentation
* supports `format` in parentheses next to the type
* moves `read only` to the top of the constraint list and makes it bold and italic (it easy to overlook before)
* Allows you to click on the section names and jump to the section heading (I could not figure out how to get the menu section names to highlight like the menu link names- someone can figure that out later)
* sets a peer dependency of json-schema-example-loader 3.0.0 and relies on its updated set of extension keywords (mostly prefixed with "cf")

For more details, see the individual commit messages.
